### PR TITLE
Switch from Passenger to gunicorn.

### DIFF
--- a/roles/web/files/bronytv.conf
+++ b/roles/web/files/bronytv.conf
@@ -1,3 +1,7 @@
+upstream btv {
+    server localhost:8000 fail_timeout=0;
+}
+
 server {
     listen 80 default_server;
 
@@ -10,7 +14,26 @@ server {
     access_log /var/log/nginx/bronytv_access.log;
     error_log /var/log/nginx/bronytv_error.log;
     root /var/www/bronytv/public;
-    passenger_enabled on;
+
+    location / {
+        try_files $uri @btv_app;
+    }
+
+    location @btv_app {
+        include proxy_params;
+        proxy_redirect off;
+        proxy_pass http://btv;
+    }
+
+    location /socket.io {
+        include proxy_params;
+        proxy_http_version 1.1;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_pass http://btv/socket.io;
+    }
 
     location ^~ /.well-known/acme-challenge/ {
         root /var/www/letsencrypt/;
@@ -43,7 +66,26 @@ server {
     server_name bronytv.net www.bronytv.net;
 
     root /var/www/bronytv/public;
-    passenger_enabled on;
+
+    location / {
+        try_files $uri @btv_app;
+    }
+
+    location @btv_app {
+        include proxy_params;
+        proxy_redirect off;
+        proxy_pass http://btv;
+    }
+
+    location /socket.io {
+        include proxy_params;
+        proxy_http_version 1.1;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_pass http://btv/socket.io;
+    }
 
     location ^~ /.well-known/acme-challenge/ {
         root /var/www/letsencrypt/;

--- a/roles/web/files/btv-gunicorn.service
+++ b/roles/web/files/btv-gunicorn.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=BronyTV gunicorn daemon
+After=network.target
+
+[Service]
+PIDFile=/run/btv-gunicorn/pid
+User=www-data
+Group=www-data
+RuntimeDirectory=btv-gunicorn
+WorkingDirectory=/var/www/bronytv
+ExecStart=/usr/local/bin/gunicorn --pid /run/btv-gunicorn/pid \
+	--bind localhost:8000 -k eventlet -w 1 passenger_wsgi
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+PrivateTmp=true
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target nginx.service

--- a/roles/web/files/nginx.conf
+++ b/roles/web/files/nginx.conf
@@ -7,8 +7,6 @@ events {
 }
 
 http {
-	passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
-	passenger_ruby /usr/bin/passenger_free_ruby;
 	sendfile on;
 	tcp_nopush on;
 	tcp_nodelay on;

--- a/roles/web/tasks/main.yml
+++ b/roles/web/tasks/main.yml
@@ -1,14 +1,9 @@
-- name: Add Phusion APT key
-  apt_key: keyserver=keyserver.ubuntu.com id=561F9B9CAC40B2F7
-- name: Add Phusion Repository
-  apt_repository: repo='deb https://oss-binaries.phusionpassenger.com/apt/passenger xenial main'
 - name: Update APT cache
   apt: update_cache=yes
 - name: Install required APT packages
   apt: name={{ item }} state=latest
   with_items:
     - nginx
-    - passenger
     - python
     - python-dev
     - libpq-dev
@@ -22,10 +17,13 @@
   with_items:
     - flask
     - flask-sqlalchemy
+    - flask-socketio
     - psycopg2
     - requests
     - bcrypt
     - alembic
+    - gunicorn
+    - eventlet
     - flask-assets
     - cssmin
     - jsmin
@@ -36,6 +34,8 @@
   copy: src=nginx.conf dest=/etc/nginx/nginx.conf owner=root group=root mode=0660
 - name: Copy nginx vhost
   copy: src=bronytv.conf dest=/etc/nginx/sites-enabled/bronytv owner=root group=root mode=0660
+- name: Copy gunicorn service
+  copy: src=btv-gunicorn.service dest=/etc/systemd/system/btv-gunicorn.service owner=root group=root mode=0660
 - name: Create website directory
   file: name=/var/www/bronytv state=directory owner=www-data group=www-data mode=0770
 
@@ -51,6 +51,10 @@
 - name: Run Alembic migrations
   command: /usr/local/bin/alembic upgrade head chdir=/var/www/bronytv 
 
+- name: Reload services
+  systemd: daemon_reload=yes
+- name: Enable gunicorn
+  systemd: name=btv-gunicorn.service enabled=yes state=restarted
 - name: Restart nginx
   service: name=nginx enabled=yes state=restarted
 


### PR DESCRIPTION
To go with the related BronyTV/bronytv.net@cb39138f22a51a1c0f5d737f87e76e0a372acf32 branch.

Note that this is not entirely tested -- I've verified that similar configuration files work but my VM setup isn't identical, and I haven't actually run ansible itself.  But in theory it should work.